### PR TITLE
Better Analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,4 @@ CDN_HOST=drwikejswixhx.cloudfront.net
 REDIS_HOST=cobia.redistogo.com
 REDIS_PORT=9130
 REDIS_PASSWORD=
-GOOGLE_ANALYTICS_KEY=
+SEGMENT_WRITE_KEY=

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,6 +7,10 @@ module.exports = function(environment) {
     baseURL: '/',
     locationType: 'auto',
     EmberENV: {},
+    segment: {
+      WRITE_KEY: process.env['SEGMENT_WRITE_KEY'] || '',
+      LOG_EVENT_TRACKING: true
+    },
 
     APP: {
       // Here you can pass flags/options to your application instance
@@ -17,10 +21,10 @@ module.exports = function(environment) {
 
   ENV.contentSecurityPolicy = {
     'default-src': "'none'",
-    'script-src': "'self' 'unsafe-eval' *.googleapis.com maps.gstatic.com browser-update.org",
+    'script-src': "'self' 'unsafe-eval' 'unsafe-inline' *.googleapis.com maps.gstatic.com browser-update.org cdn.segment.com *.getclicky.com *.google-analytics.com",
     'font-src': "'self' fonts.gstatic.com",
-    'connect-src': "'self' *.busdetective.com maps.gstatic.com",
-    'img-src': "'self' *.googleapis.com maps.gstatic.com csi.gstatic.com browser-update.org",
+    'connect-src': "'self' *.busdetective.com maps.gstatic.com api.segment.io",
+    'img-src': "'self' *.googleapis.com maps.gstatic.com csi.gstatic.com browser-update.org *.google-analytics.com",
     'style-src': "'self' 'unsafe-inline' fonts.googleapis.com maps.gstatic.com"
   };
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-moment": "0.0.2",
     "ember-cli-qunit": "0.3.13",
+    "ember-cli-segment": "0.0.5",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.17",
     "ember-deploy-redis": "0.0.2",


### PR DESCRIPTION
Migrate from straight up GA to [Segment](https://segment.com). This allows some abstraction of analytic events and will currently push to both GA and Clicky.