### PR TITLE
Change vh on height attributes to %.

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -24,3 +24,11 @@
 @import 'components/timeline';
 @import 'components/toggle-favorite';
 @import 'components/well';
+
+html, body {
+  height: 100%;
+}
+
+body > div {
+  height: 100%;
+}

--- a/app/styles/components/hero-header.scss
+++ b/app/styles/components/hero-header.scss
@@ -1,12 +1,17 @@
 .hero-header {
   // based on the golden ratio
-  $hh-height: 43.75vh;
-  $hh-padding: 3.635vh;
+  $hh-height-unitless: 43.75;
+  $hh-padding-unitless: 3.635;
+
+  $hh-height: $hh-height-unitless + 0%;
+  $hh-padding: $hh-padding-unitless + 0vh;
+
   width: 100%;
   height: $hh-height;
   padding: $hh-padding;
+
   .hero-header__logo {
-    width: $hh-height - ($hh-padding * 2);
+    width: $hh-height-unitless - ($hh-padding-unitless * 2) + 0vh;
     height: 100%;
     margin: auto;
     background-color: $bd-lighter-gray;
@@ -14,7 +19,7 @@
     box-shadow: $box-shadow;
     // Pad the container 17.5% of its diameter
     // keeps the proportions of the logo to the container consistant accross all screen sizes
-    padding: ($hh-height - ($hh-padding * 2)) * 0.175;
+    padding: ($hh-height-unitless - ($hh-padding-unitless * 2)) * 0.175 + 0vh;
   }
 }
 

--- a/app/styles/components/landing-page.scss
+++ b/app/styles/components/landing-page.scss
@@ -1,5 +1,5 @@
 .landing-container {
-  height: 100vh;
+  height: 100%;
   background-color: $bd-blue;
   & > .action-banner {
     position: relative;


### PR DESCRIPTION
This was causing issues on early versions of WebKit that support vh,
including the version of WebKit that shipped with Android KitKat. Before
that version, vh is not supported.

Resolves gaslight/bus-detective#18. @kclasita can you review and pull this in?