### PR TITLE
Sync ‘query’ param to the queryParams service

### DIFF
--- a/app/controllers/stops/search.js
+++ b/app/controllers/stops/search.js
@@ -1,10 +1,14 @@
 import Ember from 'ember';
 var inject = Ember.inject;
-var computed = Ember.computed;
 
 export default Ember.Controller.extend({
   searchQuery: inject.service(),
-  query: computed.alias('searchQuery.value'),
-  queryParams: ['query']
+  queryParams: ['query'],
+  query: null,
+  syncQueryParamToService: function() {
+    if(this.get('query')) {
+      this.set('searchQuery.query', this.get('query'));
+    }
+  }.observes('query')
 });
 


### PR DESCRIPTION
It was previously bound via a computed value, but that resulted in 
inconsistent behavior that caused the URL to lose the ‘query’ param
sometimes (especially after searching from the initial screen). This
changes it to use an observer to catch when ‘query’ is bound or changed.