### PR TITLE
Smarter polling

### DIFF
--- a/app/routes/stop/departures.js
+++ b/app/routes/stop/departures.js
@@ -1,28 +1,18 @@
 import Ember from 'ember';
-import { fetchDepartures } from 'bus-detective/utils/api';
-var run = Ember.run;
-
-const POLL_INTERVAL = 15 * 1000;
+import DepartureFetcher from 'bus-detective/utils/departure-fetcher';
 
 export default Ember.Route.extend({
-  pendingRefresh: null,
-  
-  model: function() {
-    return this.fetch();
+  beforeModel() {
+    this.set('fetcher', DepartureFetcher.create({ stopId: this.modelFor('stop').get('id') }));
   },
 
-  fetch: function() {
-    return fetchDepartures(this.modelFor('stop').get('id')).then(run.bind(this, 'handleFetchSuccess'));
-  },
-
-  handleFetchSuccess: function(departures) {
-    this.controllerFor('stop.departures').set('model', departures);
-    this.set('pendingRefresh', run.later(this, this.fetch, POLL_INTERVAL));
+  model() {
+    return this.get('fetcher').startFetching();
   },
 
   actions: {
     willTransition: function() {
-      run.cancel(this.get('pendingRefresh'));
+      this.get('fetcher').stopFetching(); 
     }
   }
 });

--- a/app/routes/stop/departures.js
+++ b/app/routes/stop/departures.js
@@ -8,22 +8,16 @@ export default Ember.Route.extend({
   pendingRefresh: null,
   
   model: function() {
-    return this.update();
+    return this.fetch();
   },
 
-  update: function() {
-    this.controllerFor('stop.departures').set('isLoading', true);
-    return fetchDepartures(this.modelFor('stop').get('id')).then(run.bind(this, 'requestDidFinish'));
+  fetch: function() {
+    return fetchDepartures(this.modelFor('stop').get('id')).then(run.bind(this, 'handleFetchSuccess'));
   },
 
-  requestDidFinish: function(departure) {
-    this.controllerFor('stop.departures').setProperties({
-      model: departure, 
-      isLoading: false 
-    });
-
-    // Enqueue a refresh
-    this.set('pendingRefresh', run.later(this, this.update, POLL_INTERVAL));
+  handleFetchSuccess: function(departures) {
+    this.controllerFor('stop.departures').set('model', departures);
+    this.set('pendingRefresh', run.later(this, this.fetch, POLL_INTERVAL));
   },
 
   actions: {

--- a/app/templates/stop/departures.hbs
+++ b/app/templates/stop/departures.hbs
@@ -1,5 +1,5 @@
 <div class="timeline">
-  {{#each model.departures as |departure|}}
+  {{#each model as |departure|}}
     {{bd-departure departure=departure class="timeline__event"}}
   {{else}}
     <p class="text-center">No departures found</p>

--- a/app/utils/departure-fetcher.js
+++ b/app/utils/departure-fetcher.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+import moment from 'moment';
+import { fetchDepartures } from 'bus-detective/utils/api';
+var run = Ember.run;
+
+const DEFAULT_POLL_INTERVAL = 15 * 1000;
+const DEFAULT_CHECK_INTERVAL = 0.5 * 1000;
+
+export default Ember.Object.extend({
+  stopId: null,
+  intervalId: null,
+
+  init() {
+    this._super();
+    this.setProperties({
+      departures: Ember.ArrayProxy.create({ content: [] }),
+      pollInterval: this.get('pollInterval') || DEFAULT_POLL_INTERVAL,
+      checkInterval: this.get('checkInterval') || DEFAULT_CHECK_INTERVAL
+    });
+  },
+
+  fetch() {
+    this.set('nextFetchTime', moment().add(this.get('pollInterval'), 'milliseconds'));
+    return fetchDepartures(this.get('stopId')).then(run.bind(this, 'handleFetchSuccess'));
+  },
+
+  fetchIfNessessary() {
+    let now = moment();
+    if (now.isAfter(this.get('nextFetchTime'))) {
+      this.fetch();
+    }
+  },
+
+  startFetching() {
+    this.set('intervalId', setInterval(run.bind(this, 'fetchIfNessessary'), this.get('checkInterval')));
+    return this.fetch();
+  },
+
+  stopFetching() {
+    clearInterval(this.get('intervalId'));
+  },
+
+  handleFetchSuccess(response) {
+    return this.get('departures').clear().pushObjects(response.get('departures'));
+  }
+});


### PR DESCRIPTION
On mobile devices, JS execution is suspended on sleep, so when the device wakes up it could potentially have stale data on the screen until the next poll event occurs (as much as 15 seconds after wake). This PR does a setInterval at 0.5 seconds that checks if it needs to refresh. 